### PR TITLE
fix: Add netlify.toml to configure build settings

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "npm run build"
+  publish = ".next"


### PR DESCRIPTION
This commit adds a `netlify.toml` file to the root of the repository to configure the build settings for Netlify.

The previous deployments were failing with a "page not found" error because Netlify was not running the build command for the Next.js application. This configuration file explicitly tells Netlify to run `npm run build` and to deploy the `.next` directory.