### PR TITLE
feat: Enhance Pose data model for AI suggestions

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -23,15 +23,27 @@ export interface User {
 // 2. Pose and Flow Data Structures
 export interface Pose {
   id: string;
-  name: string;
+  name:string;
   sanskritName: string;
   description: string;
   imageUrl: string;
   videoUrl?: string;
   difficulty: 'beginner' | 'intermediate' | 'advanced';
-  category: 'standing' | 'seated' | 'inversion' | 'restorative' | 'arm-balance' | 'back-bend';
+
+  // Enhanced metadata for AI suggestions
+  categories: ('standing' | 'seated' | 'inversion' | 'restorative' | 'arm-balance' | 'back-bend' | 'hip-opener' | 'twist' | 'forward-bend')[];
+  intensity: number; // Scale of 1-10
+  isUnilateral: boolean;
+  planeOfMotion?: 'sagittal' | 'frontal' | 'transverse';
+
   benefits: string[];
   contraindications: string[];
+
+  relatedPoseIds?: {
+    counter?: string[];
+    preparation?: string[];
+    followUp?: string[];
+  };
 }
 
 export interface FlowPose {


### PR DESCRIPTION
This commit updates the `Pose` interface in `src/types/index.ts` to include additional metadata required for the future AI-assisted flow builder.

The following changes were made:
- Replaced the singular `category` string with a more flexible `categories` array of strings.
- Added an `intensity` field (number 1-10) to gauge pose difficulty.
- Added an `isUnilateral` boolean field to identify poses that need to be performed on both sides.
- Added an optional `planeOfMotion` field.
- Added an optional `relatedPoseIds` object to define relationships like counter, preparation, and follow-up poses.

This is the first step in building the intelligent flow sequencing feature, establishing the necessary data structure for the suggestion engine.