### PR TITLE
fix: import enums as values

### DIFF
--- a/src/app/(main)/flows/create/page.tsx
+++ b/src/app/(main)/flows/create/page.tsx
@@ -17,7 +17,8 @@ import {
 import { useSpeechSynthesis } from "@/hooks/useSpeechSynthesis";
 import { useSavedFlows } from "@/hooks/useSavedFlows";
 import { useVoiceCommands } from "@/hooks/useVoiceCommands";
-import type { Focus, PoseId, SecondsOverrides, TimingMode } from "@/types/yoga";
+import type { Focus, SecondsOverrides } from "@/types/yoga";
+import { PoseId, TimingMode } from "@/types/yoga";
 
 // Yoga Flow Builder — Minimal, polished UI with safety + visuals
 // ✅ Controls bar aligned (Auto‑generate + Save inside container)

--- a/src/app/(main)/manual/ManualIndexPageClient.tsx
+++ b/src/app/(main)/manual/ManualIndexPageClient.tsx
@@ -3,7 +3,12 @@ import React, { useState } from 'react';
 import Link from 'next/link';
 import { Input } from '@/components/ui/Input';
 
-const ManualIndexPageClient = ({ toc, pages }) => {
+interface ManualIndexPageClientProps {
+  toc: string;
+  pages: { id: string }[];
+}
+
+const ManualIndexPageClient: React.FC<ManualIndexPageClientProps> = ({ toc, pages }) => {
   const [searchTerm, setSearchTerm] = useState('');
 
   const filteredPages = pages.filter(page =>

--- a/src/hooks/useSavedFlows.ts
+++ b/src/hooks/useSavedFlows.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import type { SavedFlow, PoseId } from "@/types/yoga";
+import type { SavedFlow } from "@/types/yoga";
+import { PoseId } from "@/types/yoga";
 
 export function useSavedFlows(persist: boolean) {
   const [saved, setSaved] = useState<SavedFlow[]>(() => {


### PR DESCRIPTION
## Summary
- import PoseId and TimingMode as runtime enums in flow builder
- add explicit props typing for ManualIndexPageClient
- adjust useSavedFlows to validate PoseId with runtime enum

## Testing
- `npm test`
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68beaf9ae16c832fb78dc763fdf3f3a2