### PR TITLE
Improve manual display and navigation

### DIFF
--- a/src/app/(main)/manual/ManualIndexPageClient.tsx
+++ b/src/app/(main)/manual/ManualIndexPageClient.tsx
@@ -5,14 +5,14 @@ import { Input } from '@/components/ui/Input';
 
 interface ManualIndexPageClientProps {
   toc: string;
-  pages: { id: string }[];
+  pages: { id: string; title: string }[];
 }
 
 const ManualIndexPageClient: React.FC<ManualIndexPageClientProps> = ({ toc, pages }) => {
   const [searchTerm, setSearchTerm] = useState('');
 
   const filteredPages = pages.filter(page =>
-    page.id.toLowerCase().includes(searchTerm.toLowerCase())
+    `${page.id} ${page.title}`.toLowerCase().includes(searchTerm.toLowerCase())
   );
 
   return (
@@ -27,13 +27,17 @@ const ManualIndexPageClient: React.FC<ManualIndexPageClientProps> = ({ toc, page
       />
       {searchTerm ? (
         <ul>
-          {filteredPages.map(page => (
-            <li key={page.id}>
-              <Link href={`/manual/${page.id}`}>
-                {page.id}
-              </Link>
-            </li>
-          ))}
+          {filteredPages.length > 0 ? (
+            filteredPages.map(page => (
+              <li key={page.id}>
+                <Link href={`/manual/${page.id}`}>
+                  {page.title}
+                </Link>
+              </li>
+            ))
+          ) : (
+            <li>No pages found.</li>
+          )}
         </ul>
       ) : (
         <div className="prose max-w-none" dangerouslySetInnerHTML={{ __html: toc }} />

--- a/src/app/(main)/manual/[...slug]/page.tsx
+++ b/src/app/(main)/manual/[...slug]/page.tsx
@@ -28,7 +28,7 @@ const ManualPage = async ({ params }: { params: { slug: string[] } }) => {
           {prevPage && (
             <Link href={`/manual/${prevPage.id}`}>
               <Button>
-                &larr; Previous
+                &larr; {prevPage.title}
               </Button>
             </Link>
           )}
@@ -37,7 +37,7 @@ const ManualPage = async ({ params }: { params: { slug: string[] } }) => {
           {nextPage && (
             <Link href={`/manual/${nextPage.id}`}>
               <Button>
-                Next &rarr;
+                {nextPage.title} &rarr;
               </Button>
             </Link>
           )}

--- a/src/lib/manual.ts
+++ b/src/lib/manual.ts
@@ -15,9 +15,12 @@ export function getManualPages() {
     const fullPath = path.join(pagesDirectory, filename);
     const fileContents = fs.readFileSync(fullPath, 'utf8');
     const matterResult = matter(fileContents);
+    const match = matterResult.content.trim().match(/^#\s+(.*)/);
+    const title = match ? match[1].trim() : id;
 
     return {
       id,
+      title,
       ...matterResult.data,
     };
   });
@@ -37,6 +40,8 @@ export async function getManualPage(id: string) {
 
   // Use gray-matter to parse the post metadata section
   const matterResult = matter(fileContents);
+  const match = matterResult.content.trim().match(/^#\s+(.*)/);
+  const title = match ? match[1].trim() : id;
 
   // Use remark to convert markdown into HTML string
   const processedContent = await remark()
@@ -47,6 +52,7 @@ export async function getManualPage(id: string) {
   // Combine the data with the id and contentHtml
   return {
     id,
+    title,
     contentHtml,
     ...matterResult.data,
   };


### PR DESCRIPTION
## Summary
- derive manual page titles from markdown content
- show page titles in manual search results
- display previous/next page titles for easier navigation

## Testing
- `npm test`
- `npm run lint` *(fails: How would you like to configure ESLint?)*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_e_68bed2b266f4832f9a979e199abf5d18