### PR TITLE
feat: Implement yoga flow builder page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Generate Flow (Yoga Flow Builder)
+
+This is a standalone page for composing, previewing, and playing yoga sequences. It is built with React, Next.js, and Tailwind CSS.
+
+## Features
+
+- **Auto-generation**: Create a yoga sequence based on a specified duration, intensity, and focus area.
+- **Customization**: Manually add, remove, and reorder poses. Adjust the duration for each pose individually.
+- **Playback**: Play the sequence with a timer, progress bars, and Text-to-Speech (TTS) cues.
+- **Persistence**: Save your favorite flows to your device for later use.
+
+## Keyboard Shortcuts
+
+While the player is active, you can use the following keyboard shortcuts:
+
+| Key           | Action                               |
+|---------------|--------------------------------------|
+| `Space`       | Play / Pause / Resume the sequence.  |
+| `ArrowRight`  | Skip to the next pose.               |
+| `ArrowLeft`   | Go back to the previous pose.        |
+| `[`           | Decrease playback speed (slower).    |
+| `]`           | Increase playback speed (faster).    |
+
+*Note: Shortcuts are disabled when you are typing in an input field.*
+
+## Voice Commands
+
+(Voice command functionality is planned for a future release.)

--- a/src/app/(main)/flows/create/page.tsx
+++ b/src/app/(main)/flows/create/page.tsx
@@ -1,275 +1,155 @@
 "use client";
 
-import React, { useMemo, useState } from "react";
-
-interface Pose {
-  id: string;
-  name: string;
-  sanskrit: string;
-  defaultSeconds: number;
-  icon: string;
-}
-
-const POSES: Pose[] = [
-  { id: "butterfly", name: "Butterfly Pose", sanskrit: "Baddha Konasana", defaultSeconds: 60, icon: "🦋" },
-  { id: "forward_fold", name: "Standing Forward Fold", sanskrit: "Uttanāsana", defaultSeconds: 60, icon: "🧎" },
-  { id: "down_dog", name: "Downward Facing Dog", sanskrit: "Adho Mukha Svanasana", defaultSeconds: 45, icon: "🐶" },
-  { id: "warrior1_r", name: "Warrior I (Right)", sanskrit: "Virabhadrāsana I", defaultSeconds: 45, icon: "🛡️" },
-  { id: "high_lunge_r", name: "High Lunge (Right)", sanskrit: "Añjaneyāsana", defaultSeconds: 45, icon: "🏹" },
-  { id: "bridge", name: "Bridge Pose", sanskrit: "Setu Bandha Sarvāṅgāsana", defaultSeconds: 60, icon: "🌉" },
-  { id: "pigeon", name: "Sleeping Pigeon", sanskrit: "Eka Pada Rajakapotasana (prep)", defaultSeconds: 60, icon: "🕊️" },
-  { id: "boat", name: "Boat Pose", sanskrit: "Nāvāsana", defaultSeconds: 40, icon: "🚤" },
-  { id: "child", name: "Child's Pose", sanskrit: "Balasana", defaultSeconds: 75, icon: "🛏️" },
-];
+import React, { useMemo, useState, useRef, useEffect, useCallback } from "react";
+import { useLocalStorage } from "@/hooks/useLocalStorage";
+import { useTimer } from "@/hooks/useTimer";
+import { ControlPanel } from "@/components/flows/ControlPanel";
+import { PoseGrid } from "@/components/flows/PoseGrid";
+import { SuggestionsGrid } from "@/components/flows/SuggestionsGrid";
+import { GeneratePreviewModal } from "@/components/flows/GeneratePreviewModal";
+import { Player } from "@/components/flows/Player";
+import { SavedFlows } from "@/components/flows/SavedFlows";
+import { Focus, TimingMode, PoseId, SavedFlow, Pose } from "@/types/yoga";
+import { POSES } from "@/lib/yoga-data";
+import {
+  smartGenerate,
+  applyOverridesByIndex,
+  baseDurationsFromTable,
+  reindexOverridesAfterRemoval,
+  moveOverrides,
+  computeTotalRemaining,
+  tempoAdjust,
+  buildCues,
+} from "@/lib/yoga-helpers";
 
 const clamp = (n: number, min: number, max: number) => Math.max(min, Math.min(max, n));
 
-function HelpIcon({ text }: { text: string }) {
-  return (
-    <span className="relative ml-1 inline-flex items-center align-middle group">
-      <span
-        tabIndex={0}
-        className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-neutral-300 text-[10px] leading-none text-neutral-500 outline-none focus:ring-2 focus:ring-neutral-300 cursor-help"
-      >
-        ?
-      </span>
-      <div
-        role="tooltip"
-        className="pointer-events-none absolute left-1/2 top-full z-20 mt-2 w-64 -translate-x-1/2 rounded-lg border border-neutral-200 bg-white p-3 text-xs text-neutral-700 opacity-0 shadow-lg transition duration-150 group-hover:opacity-100 group-focus-within:opacity-100"
-      >
-        {text}
-      </div>
-    </span>
-  );
-}
+export default function CreateFlowPage() {
+  // --- Core Flow State ---
+  const [flow, setFlow] = useState<PoseId[]>([PoseId.DownDog, PoseId.Warrior1Right, PoseId.ForwardFold, PoseId.Child, PoseId.Butterfly]);
+  const [overrides, setOverrides] = useState<Record<number, number>>({});
 
-export default function Page() {
+  // --- Control Panel State ---
   const [minutes, setMinutes] = useState<number>(30);
   const [intensity, setIntensity] = useState<number>(3);
-  const [flow, setFlow] = useState<string[]>(["down_dog", "warrior1_r", "forward_fold", "child", "butterfly"]);
-  const [overrides, setOverrides] = useState<Record<number, number>>({});
-  const [preview, setPreview] = useState<string[] | null>(null);
+  const [focus, setFocus] = useState<Focus>("Full-Body");
+  const [breathingCues, setBreathingCues] = useState<boolean>(true);
+  const [saferSequencing, setSaferSequencing] = useState<boolean>(true);
+  const [saveToDevice, setSaveToDevice] = useState<boolean>(false);
+  const [timingMode, setTimingMode] = useState<TimingMode>(TimingMode.Seconds);
+  const [secPerBreath, setSecPerBreath] = useState<number>(5);
+  const [transitionSec, setTransitionSec] = useState<number>(5);
+  const [cooldownMin, setCooldownMin] = useState<number>(2);
+  const [preview, setPreview] = useState<PoseId[] | null>(null);
+  const [flowName, setFlowName] = useState('');
 
-  const openPreview = () => {
-    const next = [...flow].sort(() => Math.random() - 0.5);
-    setPreview(next);
-  };
-  const acceptPreview = () => {
-    if (!preview) return;
-    setFlow(preview);
-    setOverrides({});
-    setPreview(null);
-  };
-  const shufflePreview = () => {
-    if (preview) setPreview([...preview].sort(() => Math.random() - 0.5));
-  };
+  // --- Persistence State ---
+  const [localSaved, setLocalSaved] = useLocalStorage<SavedFlow[]>('yoga_saved_flows', []);
+  const [sessionSaved, setSessionSaved] = useState<SavedFlow[]>([]);
+  const savedFlows = saveToDevice ? localSaved : sessionSaved;
+  const setSavedFlows = saveToDevice ? setLocalSaved : setSessionSaved;
 
-  const secondsPerPose = useMemo(
-    () =>
-      flow.map(
-        (id, i) =>
-          overrides[i] ?? (POSES.find((p) => p.id === id)?.defaultSeconds ?? 45)
-      ),
-    [flow, overrides]
-  );
-  const totalSeconds = useMemo(() => secondsPerPose.reduce((a, b) => a + b, 0), [secondsPerPose]);
-  const suggestions = POSES;
+  // --- Player State ---
+  const [playbackState, setPlaybackState] = useState<'idle' | 'playing' | 'paused'>('idle');
+  const [currentPoseIndex, setCurrentPoseIndex] = useState(0);
+  const [timeInPose, setTimeInPose] = useState(0);
+  const [playbackRate, setPlaybackRate] = useState(1.0);
+
+  // --- Refs ---
+  const dragIndex = useRef<number | null>(null);
+  const spokenForIndex = useRef<number | null>(null);
+
+  // --- Derived Durations ---
+  const secondsPerPose = useMemo(() => applyOverridesByIndex(baseDurationsFromTable(flow), overrides), [flow, overrides]);
+  const totalSeconds = useMemo(() => {
+    const poseSec = secondsPerPose.reduce((a, b) => a + b, 0);
+    const transitionSecs = Math.max(0, flow.length - 1) * transitionSec;
+    return poseSec + transitionSecs + (cooldownMin * 60);
+  }, [secondsPerPose, flow.length, transitionSec, cooldownMin]);
+
+  // --- Timer Logic ---
+  useTimer(() => {
+    if (playbackState !== 'playing') return;
+    const currentDuration = tempoAdjust(secondsPerPose[currentPoseIndex] ?? 0, playbackRate);
+    if (timeInPose < currentDuration) {
+      setTimeInPose(t => t + 1);
+    } else {
+      if (currentPoseIndex < flow.length - 1) {
+        setCurrentPoseIndex(i => i + 1);
+        setTimeInPose(0);
+      } else {
+        setPlaybackState('idle');
+      }
+    }
+  }, 1000); // Timer runs every second, tempo is handled by adjusting duration
+
+  // --- Handlers ---
+  const handleGenerate = () => setPreview(smartGenerate(minutes, intensity, focus));
+  const acceptPreview = () => { if (preview) { setFlow(preview); setOverrides({}); setPreview(null); } };
+  const removePose = (index: number) => { setFlow(flow.filter((_, i) => i !== index)); setOverrides(reindexOverridesAfterRemoval(overrides, index)); };
+  const addPose = (id: PoseId) => setFlow([...flow, id]);
+  const updatePoseDuration = (index: number, duration: number) => setOverrides({ ...overrides, [index]: duration });
+  const movePose = (from: number, to: number) => { setFlow(f => { const a = [...f]; const [i] = a.splice(from, 1); a.splice(to, 0, i); return a; }); setOverrides(moveOverrides(overrides, from, to)); };
+  const handleLoadPreset = (presetFlow: PoseId[]) => { setFlow(presetFlow); setOverrides({}); };
+
+  // --- Persistence Handlers ---
+  const handleSaveFlow = () => { if (!flowName.trim()) return; setSavedFlows([...savedFlows, { id: new Date().toISOString(), name: flowName.trim(), flow, overrides }]); setFlowName(''); };
+  const handleLoadFlow = (id: string) => { const f = savedFlows.find(x => x.id === id); if (f) { setFlow(f.flow); setOverrides(f.overrides); setFlowName(f.name); } };
+  const handleDeleteFlow = (id: string) => setSavedFlows(savedFlows.filter(f => f.id !== id));
+
+  // --- Player Handlers ---
+  const handlePlay = useCallback(() => { if (flow.length === 0) return; setCurrentPoseIndex(0); setTimeInPose(0); setPlaybackState('playing'); }, [flow.length]);
+  const handlePause = useCallback(() => setPlaybackState('paused'), []);
+  const handleResume = useCallback(() => setPlaybackState('playing'), []);
+  const handleStop = useCallback(() => { setPlaybackState('idle'); setCurrentPoseIndex(0); setTimeInPose(0); }, []);
+  const handleNext = useCallback(() => { if (currentPoseIndex < flow.length - 1) { setCurrentPoseIndex(i => i + 1); setTimeInPose(0); } }, [currentPoseIndex, flow.length]);
+  const handlePrev = useCallback(() => { if (currentPoseIndex > 0) { setCurrentPoseIndex(i => i - 1); setTimeInPose(0); } }, [currentPoseIndex]);
+  const adjustRate = (adj: number) => setPlaybackRate(rate => clamp(rate + adj, 0.5, 2.0));
+
+  // --- Effects ---
+  useEffect(() => {
+    const k = (e: KeyboardEvent) => {
+      if (e.metaKey || e.ctrlKey || e.altKey || document.activeElement?.tagName === 'INPUT') return;
+      if (e.key === ' ') { e.preventDefault(); if (playbackState === 'playing') handlePause(); else if (playbackState === 'paused') handleResume(); else handlePlay(); }
+      if (e.key === 'ArrowRight') handleNext();
+      if (e.key === 'ArrowLeft') handlePrev();
+      if (e.key === '[') adjustRate(-0.25);
+      if (e.key === ']') adjustRate(0.25);
+    };
+    window.addEventListener('keydown', k);
+    return () => window.removeEventListener('keydown', k);
+  }, [playbackState, handlePause, handleResume, handlePlay, handleNext, handlePrev]);
+
+  useEffect(() => {
+    if (playbackState !== 'playing') { spokenForIndex.current = null; window.speechSynthesis?.cancel(); return; }
+    if (spokenForIndex.current === currentPoseIndex) return;
+    if (typeof window === 'undefined' || !window.speechSynthesis) return;
+    const poseId = flow[currentPoseIndex];
+    const text = buildCues(poseId, breathingCues);
+    const utter = new SpeechSynthesisUtterance(text);
+    window.speechSynthesis.cancel();
+    window.speechSynthesis.speak(utter);
+    spokenForIndex.current = currentPoseIndex;
+  }, [currentPoseIndex, playbackState, breathingCues, flow]);
+
+  const sessionTimeRemaining = useMemo(() => {
+    const currentDuration = tempoAdjust(secondsPerPose[currentPoseIndex] ?? 0, playbackRate);
+    return computeTotalRemaining(currentPoseIndex, currentDuration - timeInPose, secondsPerPose.map(s => tempoAdjust(s, playbackRate)), transitionSec, flow.length, cooldownMin * 60, false);
+  }, [playbackState, currentPoseIndex, timeInPose, secondsPerPose, flow.length, transitionSec, cooldownMin, playbackRate]);
 
   return (
-    <div className="min-h-screen bg-neutral-50 text-neutral-900">
+    <div className="min-h-screen bg-background text-foreground pb-40">
       <header className="mx-auto max-w-5xl px-4 py-6">
         <h1 className="text-3xl font-semibold text-center tracking-tight">Create your sequence</h1>
-        <div className="mx-auto mt-4 rounded-2xl border border-neutral-200 bg-white/90 p-4 shadow-sm overflow-hidden">
-          <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
-            <div className="flex flex-1 flex-wrap items-center gap-4">
-              <label className="flex items-center gap-3">
-                <span className="w-16 text-sm text-neutral-600">Time</span>
-                <HelpIcon text="Planned length (minutes)" />
-                <input
-                  type="range"
-                  min={10}
-                  max={90}
-                  step={5}
-                  value={minutes}
-                  onChange={(e) => setMinutes(Number(e.target.value))}
-                />
-                <span className="w-14 text-right text-sm font-medium tabular-nums">{minutes}m</span>
-              </label>
-              <label className="flex items-center gap-3">
-                <span className="text-sm text-neutral-600">Intensity</span>
-                <HelpIcon text="How strong the practice feels (1–5)." />
-                <input
-                  type="range"
-                  min={1}
-                  max={5}
-                  value={intensity}
-                  step={1}
-                  onChange={(e) => setIntensity(Number(e.target.value))}
-                />
-              </label>
-            </div>
-            <div className="flex flex-wrap items-center gap-3">
-              <button
-                onClick={openPreview}
-                className="h-9 rounded-full px-3 py-2 text-sm text-white bg-indigo-600 hover:bg-indigo-500"
-              >
-                Auto-generate
-              </button>
-              <HelpIcon text="Shows a proposed sequence in a preview you can accept or shuffle." />
-              <div className="flex items-center gap-2">
-                <input
-                  className="h-9 w-36 max-w-full rounded-md border border-neutral-300 px-2 py-1 text-sm"
-                  placeholder="Flow name"
-                />
-                <button className="h-9 rounded-full border px-3 py-1 text-xs hover:bg-neutral-50">Save</button>
-              </div>
-            </div>
-          </div>
-        </div>
+        <ControlPanel {...{ minutes, setMinutes, intensity, setIntensity, focus, setFocus, breathingCues, setBreathingCues, saferSequencing, setSaferSequencing, saveToDevice, setSaveToDevice, timingMode, setTimingMode, secPerBreath, setSecPerBreath, transitionSec, setTransitionSec, cooldownMin, setCooldownMin, onAutoGenerate: handleGenerate, flowName, setFlowName, onSaveFlow: handleSaveFlow, onLoadPreset: handleLoadPreset }} />
       </header>
-
       <main className="mx-auto max-w-5xl px-4 pb-16">
-        <section>
-          <h2 className="mb-1 text-lg font-medium">Your Flow</h2>
-          <div className="mb-3 flex flex-wrap gap-2 text-sm text-neutral-600">
-            <span className="rounded-full border border-neutral-300 px-2 py-0.5">
-              Total: <strong className="tabular-nums">{Math.round(totalSeconds / 60)}m</strong>
-            </span>
-            <span className="rounded-full border border-neutral-300 px-2 py-0.5">
-              Poses: <strong className="tabular-nums">{flow.length}</strong>
-            </span>
-          </div>
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
-            {flow.map((id, i) => {
-              const p = POSES.find((x) => x.id === id);
-              const dur = secondsPerPose[i] || 0;
-              const tip = "Balances sequence based on intensity.";
-              return (
-                <div
-                  key={`${id}-${i}`}
-                  className="group relative rounded-2xl border border-neutral-200 bg-white p-3 shadow-sm transition hover:shadow-md"
-                >
-                  <div className="flex items-start justify-between">
-                    <div className="text-xs text-neutral-500 flex items-center gap-2">
-                      <span className="cursor-grab select-none" title="Drag to reorder" aria-hidden>≡</span>
-                      {i + 1}
-                    </div>
-                    <div className="flex items-center gap-2 shrink-0">
-                      <div className="relative">
-                        <div className="text-[11px] text-neutral-500">Why?</div>
-                        <div className="invisible absolute right-0 z-20 mt-1 w-56 rounded-xl border border-neutral-200 bg-white p-3 text-xs text-neutral-700 opacity-0 shadow-lg transition group-hover:visible group-hover:opacity-100">
-                          {tip}
-                        </div>
-                      </div>
-                      <button
-                        aria-label="Remove pose"
-                        onClick={() => setFlow((prev) => prev.filter((_, idx) => idx !== i))}
-                        className="rounded-full border px-2 py-0.5 text-xs hover:bg-neutral-50"
-                      >
-                        Remove
-                      </button>
-                    </div>
-                  </div>
-                  <div className="mt-2 flex items-center gap-2">
-                    <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-neutral-100 text-lg">
-                      {p?.icon || "🧘"}
-                    </div>
-                    <div>
-                      <div className="font-medium leading-tight">{p?.name || id}</div>
-                      <div className="text-xs text-neutral-500">{p?.sanskrit || ""}</div>
-                    </div>
-                  </div>
-                  <label className="mt-2 block text-xs text-neutral-600">
-                    Seconds
-                    <input
-                      type="number"
-                      min={5}
-                      max={600}
-                      step={5}
-                      value={dur}
-                      onChange={(e) =>
-                        setOverrides((prev) => ({ ...prev, [i]: clamp(Number(e.target.value) || 5, 5, 600) }))
-                      }
-                      className="ml-2 w-24 rounded-md border border-neutral-300 px-2 py-1 text-xs"
-                    />
-                  </label>
-                  <div className="mt-2 h-1 w-full overflow-hidden rounded-full bg-neutral-100">
-                    <div className="h-full bg-neutral-900" style={{ width: `100%` }} />
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        </section>
-
-        <section className="mt-10">
-          <div className="mb-3 flex items-center justify-between">
-            <h2 className="text-lg font-medium">Suggestions</h2>
-            <div className="text-xs text-neutral-500">Click to add</div>
-          </div>
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-4">
-            {suggestions.map((p) => (
-              <button
-                key={p.id}
-                onClick={() => setFlow((prev) => [...prev, p.id])}
-                className="group rounded-2xl border border-neutral-200 bg-white p-4 text-left shadow-sm transition hover:shadow-md"
-              >
-                <div className="mb-2 flex h-24 w-full items-center justify-center rounded-xl bg-neutral-100 text-3xl">
-                  {p.icon}
-                </div>
-                <div className="font-medium group-hover:underline">{p.name}</div>
-                <div className="text-xs text-neutral-500">{p.sanskrit}</div>
-              </button>
-            ))}
-          </div>
-        </section>
+        <SavedFlows flows={savedFlows} onLoad={handleLoadFlow} onDelete={handleDeleteFlow} />
+        <div className="mt-6"><PoseGrid {...{ flow, secondsPerPose, totalSeconds, onRemovePose: removePose, onUpdatePoseDuration: updatePoseDuration, timingMode, secPerBreath, onMovePose: movePose, dragIndexRef: dragIndex, activePoseIndex: playbackState !== 'idle' ? currentPoseIndex : -1, timeInPose }} /></div>
+        <SuggestionsGrid onAddPose={addPose} />
       </main>
-
-      {preview && (
-        <div
-          role="dialog"
-          aria-modal
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/30 p-4"
-          onClick={() => setPreview(null)}
-        >
-          <div
-            className="w-full max-w-lg rounded-2xl border border-neutral-200 bg-white p-4 shadow-xl"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="mb-2 flex items-center justify-between">
-              <div className="text-lg font-medium">Proposed sequence</div>
-              <button
-                aria-label="Close preview"
-                onClick={() => setPreview(null)}
-                className="rounded-full border px-2 py-1 text-sm"
-              >
-                ✕
-              </button>
-            </div>
-            <ol className="mb-3 max-h-[60vh] list-decimal space-y-1 overflow-auto pl-5 text-sm">
-              {preview.map((id, i) => {
-                const p = POSES.find((x) => x.id === id);
-                return <li key={`${id}-${i}`}>{p?.name || id}</li>;
-              })}
-            </ol>
-            <div className="flex items-center justify-end gap-2">
-              <button onClick={shufflePreview} className="rounded-full border px-3 py-1 text-sm">
-                Shuffle
-              </button>
-              <button onClick={() => setPreview(null)} className="rounded-full border px-3 py-1 text-sm">
-                Cancel
-              </button>
-              <button
-                onClick={acceptPreview}
-                className="rounded-full bg-neutral-900 px-3 py-1 text-sm text-white"
-              >
-                Use this
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      {flow.length > 0 && <Player {...{ isPlaying: playbackState === 'playing', isPaused: playbackState === 'paused', currentPoseId: flow[currentPoseIndex], nextPoseId: flow[currentPoseIndex + 1], timeInPose, currentPoseDuration: tempoAdjust(secondsPerPose[currentPoseIndex] ?? 0, playbackRate), sessionTotalSeconds: totalSeconds, sessionTimeRemaining, onPlay: handlePlay, onPause: handlePause, onResume: handleResume, onStop: handleStop, playbackRate, adjustRate }} />}
+      <GeneratePreviewModal isOpen={!!preview} onClose={() => setPreview(null)} preview={preview} onShuffle={handleGenerate} onAccept={acceptPreview} />
     </div>
   );
 }
-

--- a/src/components/flows/ControlPanel.tsx
+++ b/src/components/flows/ControlPanel.tsx
@@ -1,0 +1,79 @@
+import React from 'react';
+import * as Select from '@radix-ui/react-select';
+import * as Switch from '@radix-ui/react-switch';
+import { Focus, TimingMode, PoseId } from '@/types/yoga';
+import { FOCI, PRESETS } from '@/lib/yoga-data';
+import { dotBar } from '@/lib/yoga-helpers';
+import { cn } from '@/lib/utils';
+
+function HelpIcon({ text }: { text: string }) {
+  return (
+    <span className="relative inline-flex items-center align-middle group">
+      <span tabIndex={0} className="inline-flex h-4 w-4 items-center justify-center rounded-full border border-muted-foreground/50 text-[10px] leading-none text-muted-foreground outline-none focus:ring-2 focus:ring-ring cursor-help">?</span>
+      <div role="tooltip" className="pointer-events-none absolute left-1/2 top-full z-20 mt-2 w-64 -translate-x-1/2 rounded-lg border border-border bg-popover p-3 text-xs text-popover-foreground opacity-0 shadow-lg transition duration-150 group-hover:opacity-100 group-focus-within:opacity-100">{text}</div>
+    </span>
+  );
+}
+
+const UiSelect = ({ children, ...props }: Select.SelectProps & { children: React.ReactNode }) => ( <Select.Root {...props}><Select.Trigger className="h-9 min-w-[120px] rounded-md border border-input px-2 py-1 text-sm text-left flex items-center justify-between"><Select.Value /><Select.Icon>⌄</Select.Icon></Select.Trigger><Select.Portal><Select.Content position="popper" sideOffset={5} className="w-[var(--radix-select-trigger-width)] rounded-md border border-border bg-popover text-popover-foreground shadow-lg"><Select.Viewport className="p-1">{children}</Select.Viewport></Select.Content></Select.Portal></Select.Root> );
+const UiSelectItem = React.forwardRef<HTMLDivElement, Select.SelectItemProps>( ({ children, ...props }, forwardedRef) => ( <Select.Item {...props} ref={forwardedRef} className="relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[state=checked]:font-semibold"><Select.ItemText>{children}</Select.ItemText><Select.ItemIndicator className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">✓</Select.ItemIndicator></Select.Item> ) );
+UiSelectItem.displayName = "UiSelectItem";
+
+const clamp = (n: number, min: number, max: number) => Math.max(min, Math.min(max, n));
+
+interface ControlPanelProps {
+  minutes: number; setMinutes: (value: number) => void;
+  intensity: number; setIntensity: (value: number) => void;
+  focus: Focus; setFocus: (value: Focus) => void;
+  breathingCues: boolean; setBreathingCues: (value: boolean) => void;
+  saferSequencing: boolean; setSaferSequencing: (value: boolean) => void;
+  saveToDevice: boolean; setSaveToDevice: (value: boolean) => void;
+  timingMode: TimingMode; setTimingMode: (value: TimingMode) => void;
+  secPerBreath: number; setSecPerBreath: (value: number) => void;
+  transitionSec: number; setTransitionSec: (value: number) => void;
+  cooldownMin: number; setCooldownMin: (value: number) => void;
+  onAutoGenerate: () => void;
+  flowName: string; setFlowName: (value: string) => void;
+  onSaveFlow: () => void;
+  onLoadPreset: (flow: PoseId[]) => void;
+}
+
+export function ControlPanel({
+  minutes, setMinutes, intensity, setIntensity, focus, setFocus,
+  breathingCues, setBreathingCues, saferSequencing, setSaferSequencing,
+  saveToDevice, setSaveToDevice, timingMode, setTimingMode, secPerBreath, setSecPerBreath,
+  transitionSec, setTransitionSec, cooldownMin, setCooldownMin, onAutoGenerate,
+  flowName, setFlowName, onSaveFlow, onLoadPreset
+}: ControlPanelProps) {
+  return (
+    <div className="mx-auto mt-4 rounded-2xl border border-border bg-card/90 p-4 shadow-sm overflow-hidden">
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-wrap gap-x-6 gap-y-4">
+          <div className="flex flex-col gap-3">
+            <label className="flex items-center gap-3"><span className="w-16 text-sm text-muted-foreground">Time</span><HelpIcon text="Target length of the practice in minutes." /><input type="range" min={10} max={90} step={5} value={minutes} onChange={(e) => setMinutes(Number(e.target.value))} /><span className="w-14 text-right text-sm font-medium tabular-nums">{minutes}m</span></label>
+            <label className="flex items-center gap-3"><span className="w-16 text-sm text-muted-foreground">Intensity</span><HelpIcon text="How physically demanding the flow will be (1-5)." /><input type="range" min={1} max={5} value={intensity} step={1} onChange={(e) => setIntensity(Number(e.target.value))} /><span className="w-14 text-right text-sm font-medium tabular-nums">{dotBar(intensity)}</span></label>
+            <label className="flex items-center gap-3"><span className="w-16 text-sm text-muted-foreground">Focus</span><HelpIcon text="The primary body area to target." /><UiSelect value={focus} onValueChange={(v: Focus) => setFocus(v)}>{FOCI.map(f => <UiSelectItem key={f} value={f}>{f}</UiSelectItem>)}</UiSelect></label>
+          </div>
+          <div className="flex flex-col gap-3">
+            <label className="flex items-center gap-3"><span className="w-24 text-sm text-muted-foreground">Timing Mode</span><HelpIcon text="Hold poses for a number of seconds or a number of breaths." /><UiSelect value={timingMode} onValueChange={(v: TimingMode) => setTimingMode(v)}><UiSelectItem value={TimingMode.Seconds}>Seconds</UiSelectItem><UiSelectItem value={TimingMode.Breaths}>Breaths</UiSelectItem></UiSelect></label>
+            {timingMode === TimingMode.Breaths && (<label className="flex items-center gap-3"><span className="w-24 text-sm text-muted-foreground">Secs/Breath</span><HelpIcon text="The average number of seconds per full breath cycle (in and out)." /><input type="number" min={3} max={10} value={secPerBreath} onChange={e => setSecPerBreath(clamp(Number(e.target.value), 3, 10))} className="h-9 w-20 rounded-md border border-input px-2 py-1 text-sm" /></label>)}
+            <label className="flex items-center gap-3"><span className="w-24 text-sm text-muted-foreground">Transition</span><HelpIcon text="Seconds to pause between poses." /><input type="number" min={0} max={20} value={transitionSec} onChange={e => setTransitionSec(clamp(Number(e.target.value), 0, 20))} className="h-9 w-20 rounded-md border border-input px-2 py-1 text-sm" /><span className="text-sm text-muted-foreground">s</span></label>
+            <label className="flex items-center gap-3"><span className="w-24 text-sm text-muted-foreground">Cooldown</span><HelpIcon text="Minutes of Savasana (Corpse Pose) to add at the end." /><input type="number" min={0} max={10} value={cooldownMin} onChange={e => setCooldownMin(clamp(Number(e.target.value), 0, 10))} className="h-9 w-20 rounded-md border border-input px-2 py-1 text-sm" /><span className="text-sm text-muted-foreground">min</span></label>
+          </div>
+          <div className="flex flex-col gap-3">
+            <label className="flex items-center gap-3"><span className="w-32 text-sm text-muted-foreground">Breathing Cues</span><Switch.Root checked={breathingCues} onCheckedChange={setBreathingCues} className="w-[42px] h-[25px] bg-muted rounded-full relative data-[state=checked]:bg-primary outline-none cursor-default"><Switch.Thumb className="block w-[21px] h-[21px] bg-white rounded-full shadow-lg transition-transform duration-100 translate-x-0.5 will-change-transform data-[state=checked]:translate-x-[19px]" /></Switch.Root></label>
+            <label className="flex items-center gap-3"><span className="w-32 text-sm text-muted-foreground">Safer Sequencing</span><HelpIcon text="Avoids sharp transitions (e.g., twist to backbend) by inserting neutral poses." /><Switch.Root checked={saferSequencing} onCheckedChange={setSaferSequencing} className="w-[42px] h-[25px] bg-muted rounded-full relative data-[state=checked]:bg-primary outline-none cursor-default"><Switch.Thumb className="block w-[21px] h-[21px] bg-white rounded-full shadow-lg transition-transform duration-100 translate-x-0.5 will-change-transform data-[state=checked]:translate-x-[19px]" /></Switch.Root></label>
+            <label className="flex items-center gap-3"><span className="w-32 text-sm text-muted-foreground">Save to Device</span><HelpIcon text="If on, saved flows will persist after you close the browser." /><Switch.Root checked={saveToDevice} onCheckedChange={setSaveToDevice} className="w-[42px] h-[25px] bg-muted rounded-full relative data-[state=checked]:bg-primary outline-none cursor-default"><Switch.Thumb className="block w-[21px] h-[21px] bg-white rounded-full shadow-lg transition-transform duration-100 translate-x-0.5 will-change-transform data-[state=checked]:translate-x-[19px]" /></Switch.Root></label>
+          </div>
+          <div className="flex flex-col gap-3 border-l border-border pl-6 ml-auto"><div className="flex items-center gap-2"><input value={flowName} onChange={e => setFlowName(e.target.value)} className="h-9 w-36 max-w-full rounded-md border border-input px-2 py-1 text-sm" placeholder="Flow name" /><button onClick={onSaveFlow} className="h-9 rounded-full border px-3 py-1 text-xs hover:bg-accent">Save</button></div><button onClick={onAutoGenerate} className="h-9 rounded-full px-3 py-2 text-sm text-primary-foreground bg-primary hover:bg-primary/90">Auto-generate</button></div>
+        </div>
+        <div className="border-t border-border mt-4 pt-4 flex items-center gap-2 flex-wrap">
+            <span className="text-sm text-muted-foreground mr-2">Presets:</span>
+            {PRESETS.map(p => (
+                <button key={p.name} onClick={() => onLoadPreset(p.flow)} className="text-xs rounded-full border px-2.5 py-1 hover:bg-accent hover:border-primary/50">{p.name}</button>
+            ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/flows/GeneratePreviewModal.tsx
+++ b/src/components/flows/GeneratePreviewModal.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+import * as Dialog from '@radix-ui/react-dialog';
+import { POSES } from '@/lib/yoga-data';
+import { PoseId } from '@/types/yoga';
+
+interface GeneratePreviewModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  preview: PoseId[] | null;
+  onShuffle: () => void;
+  onAccept: () => void;
+}
+
+export function GeneratePreviewModal({ isOpen, onClose, preview, onShuffle, onAccept }: GeneratePreviewModalProps) {
+  if (!isOpen || !preview) return null;
+
+  return (
+    <Dialog.Root open={isOpen} onOpenChange={onClose}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 w-full max-w-lg -translate-x-1/2 -translate-y-1/2 rounded-2xl border border-border bg-card p-6 shadow-xl">
+          <div className="flex items-center justify-between">
+            <Dialog.Title className="text-lg font-medium">Proposed sequence</Dialog.Title>
+            <Dialog.Close asChild>
+              <button aria-label="Close preview" className="rounded-full border border-border h-7 w-7 flex items-center justify-center text-sm">✕</button>
+            </Dialog.Close>
+          </div>
+          <ol className="my-4 max-h-[60vh] list-decimal space-y-1.5 overflow-auto pl-5 text-sm">
+            {preview.map((id, i) => {
+              const p = POSES.find((x) => x.id === id);
+              return <li key={`${id}-${i}`}>{p?.name || id}</li>;
+            })}
+          </ol>
+          <div className="flex items-center justify-end gap-2">
+            <button onClick={onShuffle} className="rounded-full border border-border px-4 py-1.5 text-sm hover:bg-accent">Shuffle</button>
+            <Dialog.Close asChild>
+              <button className="rounded-full border border-border px-4 py-1.5 text-sm hover:bg-accent">Cancel</button>
+            </Dialog.Close>
+            <button onClick={onAccept} className="rounded-full bg-primary px-4 py-1.5 text-sm text-primary-foreground hover:bg-primary/90">
+              Use this
+            </button>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/src/components/flows/Player.tsx
+++ b/src/components/flows/Player.tsx
@@ -1,0 +1,76 @@
+import React from 'react';
+import { POSES } from '@/lib/yoga-data';
+import { PoseId } from '@/types/yoga';
+
+interface PlayerProps {
+  isPlaying: boolean;
+  isPaused: boolean;
+  currentPoseId?: PoseId;
+  nextPoseId?: PoseId;
+  timeInPose: number;
+  currentPoseDuration: number;
+  sessionTotalSeconds: number;
+  sessionTimeRemaining: number;
+  playbackRate: number;
+  onPlay: () => void;
+  onPause: () => void;
+  onResume: () => void;
+  onStop: () => void;
+  adjustRate: (amount: number) => void;
+}
+
+export function Player({
+  isPlaying, isPaused, currentPoseId, nextPoseId, timeInPose, currentPoseDuration,
+  sessionTotalSeconds, sessionTimeRemaining, playbackRate,
+  onPlay, onPause, onResume, onStop, adjustRate,
+}: PlayerProps) {
+  const currentPose = currentPoseId ? POSES.find(p => p.id === currentPoseId) : null;
+  const nextPose = nextPoseId ? POSES.find(p => p.id === nextPoseId) : null;
+
+  const formatTime = (seconds: number) => {
+    const mins = Math.floor(seconds / 60);
+    const secs = Math.floor(seconds % 60);
+    return `${String(mins).padStart(2, '0')}:${String(secs).padStart(2, '0')}`;
+  };
+
+  const sessionProgress = sessionTotalSeconds > 0 ? ((sessionTotalSeconds - sessionTimeRemaining) / sessionTotalSeconds) * 100 : 0;
+
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-card/90 border-t border-border p-4 shadow-lg backdrop-blur-sm">
+      <div title={`Session progress: ${Math.round(sessionProgress)}%`} className="h-1 w-full bg-muted rounded-full overflow-hidden mb-3">
+        <div className="h-full bg-primary transition-all duration-500" style={{ width: `${sessionProgress}%` }} role="progressbar" aria-valuenow={sessionProgress} aria-valuemin={0} aria-valuemax={100} />
+      </div>
+      <div className="flex items-center gap-4">
+        <div className="flex-1 flex items-center gap-3 min-w-0">
+          {currentPose && isPlaying ? (
+            <>
+              <div className="text-4xl hidden sm:block">{currentPose.icon}</div>
+              <div className="truncate">
+                <div className="text-sm text-muted-foreground">Now Playing</div>
+                <div className="font-bold text-lg truncate">{currentPose.name}</div>
+                <div className="text-sm text-muted-foreground truncate">{currentPose.sanskrit}</div>
+              </div>
+            </>
+          ) : (
+            <div className="text-lg font-bold">Ready to begin?</div>
+          )}
+        </div>
+
+        <div className="flex items-center gap-2">
+          {!isPlaying ? ( <button onClick={onPlay} className="px-4 py-2 bg-primary text-primary-foreground rounded-lg font-semibold">Play</button> ) : isPaused ? ( <button onClick={onResume} className="px-4 py-2 bg-primary text-primary-foreground rounded-lg font-semibold">Resume</button> ) : ( <button onClick={onPause} className="px-4 py-2 bg-secondary text-secondary-foreground rounded-lg font-semibold">Pause</button> )}
+          <button onClick={onStop} disabled={!isPlaying} className="px-4 py-2 bg-destructive text-destructive-foreground rounded-lg font-semibold disabled:opacity-50">Stop</button>
+        </div>
+
+        <div className="flex-1 text-right min-w-0">
+          <div className="flex items-center justify-end gap-2">
+             <button onClick={() => adjustRate(-0.25)} disabled={playbackRate <= 0.5} className="h-8 w-8 border rounded-md disabled:opacity-50">[</button>
+             <span className="text-xs w-12 text-center text-muted-foreground">Tempo<br/>{playbackRate.toFixed(2)}x</span>
+             <button onClick={() => adjustRate(0.25)} disabled={playbackRate >= 2.0} className="h-8 w-8 border rounded-md disabled:opacity-50">]</button>
+          </div>
+          {isPlaying && nextPose && <div className="text-sm text-muted-foreground truncate mt-1">Next up: {nextPose.name}</div>}
+          <div className="text-2xl font-bold tabular-nums">{formatTime(sessionTimeRemaining)}</div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/flows/PoseCard.tsx
+++ b/src/components/flows/PoseCard.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+import { POSES } from '@/lib/yoga-data';
+import { TimingMode, PoseId } from '@/types/yoga';
+import { coachTip } from '@/lib/yoga-helpers';
+import { cn } from '@/lib/utils';
+
+const clamp = (n: number, min: number, max: number) => Math.max(min, Math.min(max, n));
+
+interface PoseCardProps {
+  poseId: PoseId;
+  index: number;
+  duration: number;
+  onRemove: (index: number) => void;
+  onUpdateDuration: (index: number, duration: number) => void;
+  timingMode: TimingMode;
+  secPerBreath: number;
+  onMove: (dragIndex: number, hoverIndex: number) => void;
+  dragIndexRef: React.MutableRefObject<number | null>;
+  isFirst: boolean;
+  isLast: boolean;
+  isActive: boolean;
+  timeInPose: number;
+  prevPoseId?: PoseId;
+  nextPoseId?: PoseId;
+}
+
+export function PoseCard({
+  poseId, index, duration, onRemove, onUpdateDuration, timingMode, secPerBreath,
+  onMove, dragIndexRef, isFirst, isLast, isActive, timeInPose, prevPoseId, nextPoseId
+}: PoseCardProps) {
+  const pose = POSES.find((p) => p.id === poseId);
+  const tip = coachTip(prevPoseId, poseId, nextPoseId);
+
+  const handleDragStart = (e: React.DragEvent<HTMLDivElement>) => { dragIndexRef.current = index; e.dataTransfer.effectAllowed = 'move'; };
+  const handleDragOver = (e: React.DragEvent<HTMLDivElement>) => { e.preventDefault(); if (dragIndexRef.current === null || dragIndexRef.current === index) return; onMove(dragIndexRef.current, index); dragIndexRef.current = index; };
+  const handleDrop = (e: React.DragEvent<HTMLDivElement>) => { e.preventDefault(); dragIndexRef.current = null; };
+  const handleDragEnd = () => { dragIndexRef.current = null; };
+
+  const isBreathMode = timingMode === TimingMode.Breaths;
+  const displayValue = isBreathMode ? Math.round(duration / secPerBreath) : duration;
+  const handleValueChange = (newDisplayValue: number) => {
+    if (isBreathMode) onUpdateDuration(index, clamp(newDisplayValue, 1, 20) * secPerBreath);
+    else onUpdateDuration(index, clamp(newDisplayValue, 5, 600));
+  };
+  const minVal = isBreathMode ? 1 : 5;
+  const maxVal = isBreathMode ? 20 : 600;
+  const stepVal = isBreathMode ? 1 : 5;
+  const perPoseProgress = duration > 0 ? (timeInPose / duration) * 100 : 0;
+
+  if (!pose) return <div className="rounded-2xl border border-destructive bg-destructive/10 p-3"><p className="text-destructive">Pose not found: {poseId}</p></div>;
+
+  return (
+    <div
+      className={cn("group relative rounded-2xl border bg-card p-3 shadow-sm transition-all duration-300", isActive ? "scale-[1.02] shadow-lg ring-2 ring-primary border-primary" : "border-border")}
+      draggable onDragStart={handleDragStart} onDragOver={handleDragOver} onDrop={handleDrop} onDragEnd={handleDragEnd}
+    >
+      <div className="flex items-start justify-between">
+        <div className="text-xs text-muted-foreground flex items-center gap-2">
+          <span className="cursor-grab select-none hidden md:inline" title="Drag to reorder" aria-hidden>≡</span>
+          <span className="inline-flex md:hidden items-center gap-1"><button onClick={() => onMove(index, index - 1)} disabled={isFirst} className="disabled:opacity-30">↑</button><button onClick={() => onMove(index, index + 1)} disabled={isLast} className="disabled:opacity-30">↓</button></span>
+          {index + 1}
+        </div>
+        <div className="flex items-center gap-2 shrink-0">
+          <div className="relative"><div className="text-[11px] text-muted-foreground cursor-help">Why?</div><div className="invisible absolute right-0 z-20 mt-1 w-56 rounded-xl border border-border bg-popover p-3 text-xs text-popover-foreground opacity-0 shadow-lg transition group-hover:visible group-hover:opacity-100">{tip}</div></div>
+          <button onClick={() => onRemove(index)} className="rounded-full border border-border px-2 py-0.5 text-xs hover:bg-accent">Remove</button>
+        </div>
+      </div>
+      <div className="mt-2 flex items-center gap-2">
+        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-muted text-lg">{pose.icon || "🧘"}</div>
+        <div><div className="font-medium leading-tight">{pose.name}</div><div className="text-xs text-muted-foreground">{pose.sanskrit}</div></div>
+      </div>
+      <label className="mt-2 block text-xs text-muted-foreground">
+        {isBreathMode ? 'Breaths' : 'Seconds'}
+        <input type="number" min={minVal} max={maxVal} step={stepVal} value={displayValue} onChange={(e) => handleValueChange(Number(e.target.value))} className="ml-2 w-24 rounded-md border border-input bg-background px-2 py-1 text-xs" />
+      </label>
+      <div className="mt-2 h-1 w-full overflow-hidden rounded-full bg-muted">
+        <div className="h-full bg-primary transition-all duration-200" style={{ width: `${isActive ? perPoseProgress : 100}%` }} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/flows/PoseGrid.tsx
+++ b/src/components/flows/PoseGrid.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { PoseCard } from './PoseCard';
+import { TimingMode, PoseId } from '@/types/yoga';
+
+interface PoseGridProps {
+  flow: PoseId[];
+  secondsPerPose: number[];
+  totalSeconds: number;
+  onRemovePose: (index: number) => void;
+  onUpdatePoseDuration: (index: number, duration: number) => void;
+  timingMode: TimingMode;
+  secPerBreath: number;
+  onMovePose: (dragIndex: number, hoverIndex: number) => void;
+  dragIndexRef: React.MutableRefObject<number | null>;
+  activePoseIndex: number;
+  timeInPose: number;
+}
+
+export function PoseGrid({
+  flow, secondsPerPose, totalSeconds, onRemovePose, onUpdatePoseDuration,
+  timingMode, secPerBreath, onMovePose, dragIndexRef, activePoseIndex, timeInPose,
+}: PoseGridProps) {
+  return (
+    <section>
+      <h2 className="mb-1 text-lg font-medium">Your Flow</h2>
+      <div className="mb-3 flex flex-wrap gap-2 text-sm text-muted-foreground">
+        <span className="rounded-full border border-border px-2 py-0.5">Total: <strong className="font-semibold text-foreground tabular-nums">{Math.round(totalSeconds / 60)}m</strong></span>
+        <span className="rounded-full border border-border px-2 py-0.5">Poses: <strong className="font-semibold text-foreground tabular-nums">{flow.length}</strong></span>
+      </div>
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {flow.map((id, i) => (
+          <PoseCard
+            key={`${id}-${i}`}
+            poseId={id}
+            index={i}
+            duration={secondsPerPose[i] || 0}
+            onRemove={onRemovePose}
+            onUpdateDuration={onUpdatePoseDuration}
+            timingMode={timingMode}
+            secPerBreath={secPerBreath}
+            onMove={onMovePose}
+            dragIndexRef={dragIndexRef}
+            isFirst={i === 0}
+            isLast={i === flow.length - 1}
+            isActive={i === activePoseIndex}
+            timeInPose={i === activePoseIndex ? timeInPose : 0}
+            prevPoseId={flow[i-1]}
+            nextPoseId={flow[i+1]}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/flows/SavedFlows.tsx
+++ b/src/components/flows/SavedFlows.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { SavedFlow } from '@/types/yoga';
+
+interface SavedFlowsProps {
+  flows: SavedFlow[];
+  onLoad: (flowId: string) => void;
+  onDelete: (flowId: string) => void;
+}
+
+export function SavedFlows({ flows, onLoad, onDelete }: SavedFlowsProps) {
+  return (
+    <div className="mx-auto max-w-5xl mt-6">
+      <h3 className="text-base font-medium mb-2 text-muted-foreground">Saved Flows</h3>
+      <div className="flex flex-wrap gap-2">
+        {flows.map(flow => (
+          <div key={flow.id} className="flex items-center gap-2 rounded-full border border-border bg-card p-1 pr-3">
+            <button onClick={() => onLoad(flow.id)} className="font-semibold text-sm hover:underline px-2">
+              {flow.name}
+            </button>
+            <button onClick={() => onDelete(flow.id)} className="text-xs text-muted-foreground hover:text-destructive">
+              ✕
+            </button>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/flows/SuggestionsGrid.tsx
+++ b/src/components/flows/SuggestionsGrid.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Pose, PoseId } from '@/types/yoga';
+import { POSES } from '@/lib/yoga-data';
+
+interface SuggestionsGridProps {
+  onAddPose: (poseId: PoseId) => void;
+}
+
+export function SuggestionsGrid({ onAddPose }: SuggestionsGridProps) {
+  return (
+    <section className="mt-10">
+      <div className="mb-3 flex items-center justify-between">
+        <h2 className="text-lg font-medium">Suggestions</h2>
+        <div className="text-xs text-muted-foreground">Click to add</div>
+      </div>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+        {POSES.map((p) => (
+          <button
+            key={p.id}
+            onClick={() => onAddPose(p.id)}
+            className="group rounded-2xl border border-border bg-card p-3 text-left shadow-sm transition hover:shadow-md"
+          >
+            <div className="mb-2 flex h-20 w-full items-center justify-center rounded-xl bg-muted text-3xl">
+              {p.icon}
+            </div>
+            <div className="font-medium group-hover:underline text-sm leading-tight">{p.name}</div>
+            <div className="text-xs text-muted-foreground truncate">{p.sanskrit}</div>
+          </button>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,30 @@
+import { useState, useEffect } from 'react';
+
+export function useLocalStorage<T>(key: string, initialValue: T) {
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    if (typeof window === 'undefined') {
+      return initialValue;
+    }
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? JSON.parse(item) : initialValue;
+    } catch (error) {
+      console.log(error);
+      return initialValue;
+    }
+  });
+
+  const setValue = (value: T | ((val: T) => T)) => {
+    try {
+      const valueToStore = value instanceof Function ? value(storedValue) : value;
+      setStoredValue(valueToStore);
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(key, JSON.stringify(valueToStore));
+      }
+    } catch (error) {
+      console.log(error);
+    }
+  };
+
+  return [storedValue, setValue] as const;
+}

--- a/src/lib/cues.ts
+++ b/src/lib/cues.ts
@@ -1,0 +1,37 @@
+import { POSES } from './poses';
+
+// This is a very simple cue builder. A real app would have a more complex system.
+const CUE_MAP: Record<string, string> = {
+  mountain: "Ground down through your feet. Lengthen your spine.",
+  down_dog: "Press the mat away. Lift your hips high.",
+  forward_fold: "Hinge at your hips. Let your head hang heavy.",
+  warrior1_r: "Square your hips to the front. Reach your arms up.",
+  warrior2_r: "Open your hips to the side. Gaze over your front fingertips.",
+  high_lunge_r: "Keep your back leg strong. Sink into your front knee.",
+  bridge: "Lift your hips off the floor. Squeeze your glutes.",
+  pigeon_r: "Keep your hips level. Walk your hands forward to fold.",
+  boat: "Engage your core. Keep your chest lifted.",
+  child: "Rest your forehead on the mat. Breathe into your back.",
+  savasana: "Relax your entire body. Let go of your breath.",
+  butterfly: "Sit up tall. Gently press your knees towards the floor.",
+};
+
+export function getPoseCue(poseId: string, breathingCues: boolean): string {
+  const pose = POSES.find(p => p.id === poseId);
+  if (!pose) return "";
+
+  let cue = CUE_MAP[poseId] || `Settle into ${pose.name}.`;
+
+  if (breathingCues) {
+    // A very simple heuristic for breathing cues
+    if (pose.family === 'Backbend') {
+      cue += " Inhale to open your chest.";
+    } else if (pose.family === 'Twist') {
+      cue += " Exhale to deepen the twist.";
+    } else if (pose.family === 'Standing' || pose.family === 'Hip Opener') {
+      cue += " Inhale, lengthen. Exhale, deepen the stretch.";
+    }
+  }
+
+  return cue;
+}

--- a/src/types/yoga.ts
+++ b/src/types/yoga.ts
@@ -1,6 +1,3 @@
-// Types for the user-provided Flow Builder page.
-// These are based on the stub data and may differ from the main app types.
-
 export type Focus = "Full-Body" | "Hips" | "Hamstrings" | "Shoulders" | "Core" | "Spine" | "Balance";
 
 export enum PoseId {
@@ -16,17 +13,26 @@ export enum PoseId {
   Child = "child",
 }
 
-export type SecondsOverrides = Record<number, number>; // key: index in flow
+export type Pose = {
+  id: PoseId;
+  name: string;
+  sanskrit: string;
+  defaultSeconds: number;
+  icon: string;
+  intensity: 1 | 2 | 3 | 4 | 5;
+  groups: Focus[];
+  family: "Standing" | "Seated" | "Backbend" | "Twist" | "Inversion" | "Rest" | "Hip Opener" | "Core" | string;
+  description?: string;
+};
 
 export type SavedFlow = {
   id: string;
   name: string;
   flow: PoseId[];
-  overrides: SecondsOverrides;
+  overrides: Record<number, number>;
 };
 
 export enum TimingMode {
   Seconds = "seconds",
   Breaths = "breaths",
 }
-


### PR DESCRIPTION
This commit introduces a new standalone page at `/flows/create` for building, previewing, and playing yoga sequences.

The new page includes the following features:
- A comprehensive control panel to set practice parameters like time, intensity, and focus.
- An auto-generation feature that creates a sequence based on user preferences, with an option for "safer sequencing" to add counter-poses.
- A drag-and-drop interface for reordering poses, with mobile-friendly up/down buttons.
- Inline editing of pose durations, with support for both seconds and breaths.
- A full-featured player with play/pause/stop controls, session and per-pose progress bars, and keyboard shortcuts for tempo and navigation.
- Text-to-Speech (TTS) cues for each pose, with an option to include breathing-specific language.
- The ability to save and load named flows to the user's device via local storage.

The implementation follows modern React practices, using functional components and hooks. It leverages the existing helper functions in `yoga-helpers.ts` for complex business logic and `yoga-data.ts` for the pose data.