### PR TITLE
Fix type mismatch in Pose and update speech recognition typing

### DIFF
--- a/src/lib/voice/useSpeechRecognition.ts
+++ b/src/lib/voice/useSpeechRecognition.ts
@@ -8,12 +8,13 @@ export function useSpeechRecognition() {
   const [interimTranscript, setInterimTranscript] = useState('');
   const [error, setError] = useState<string | null>(null);
 
-  const recognitionRef = useRef<SpeechRecognition | null>(null);
+  // Using `any` as the Web Speech API types may not be available in all environments
+  const recognitionRef = useRef<any>(null);
   const debounceTimer = useRef<NodeJS.Timeout | null>(null);
 
   useEffect(() => {
     if (typeof window === 'undefined') return;
-    const SpeechRecognitionAPI = window.SpeechRecognition || window.webkitSpeechRecognition;
+    const SpeechRecognitionAPI = (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
     if (!SpeechRecognitionAPI) {
       setError("Speech recognition is not supported in this browser.");
       return;
@@ -24,7 +25,7 @@ export function useSpeechRecognition() {
     recognition.interimResults = true;
     recognitionRef.current = recognition;
 
-    recognition.onresult = (event) => {
+    recognition.onresult = (event: any) => {
       if (debounceTimer.current) clearTimeout(debounceTimer.current);
 
       let final = '';
@@ -47,7 +48,7 @@ export function useSpeechRecognition() {
       }, DEBOUNCE_TIME);
     };
 
-    recognition.onerror = (event) => { setError(event.error); setListening(false); };
+    recognition.onerror = (event: any) => { setError(event.error); setListening(false); };
     recognition.onend = () => { setListening(false); };
 
     return () => { recognition.stop(); };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,7 +24,7 @@ export interface User {
 export interface Pose {
   id: string;
   name:string;
-  sanskritName: string;
+  sanskrit: string;
   description: string;
   imageUrl: string;
   videoUrl?: string;


### PR DESCRIPTION
## Summary
- rename `sanskritName` to `sanskrit` in Pose type
- loosen speech recognition typings for compatibility with environments lacking Web Speech API types

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c13d8950ac832fbe986898d641a2f7