### PR TITLE
feat: expand dashboard actions and presets

### DIFF
--- a/src/app/(main)/dashboard/page.tsx
+++ b/src/app/(main)/dashboard/page.tsx
@@ -1,21 +1,44 @@
-import React from 'react';
+"use client";
+
+import React, { useState } from 'react';
 import { AIFlowGenerator } from '@/components/flows/AIFlowGenerator';
+import { PresetFlowsRow } from '@/components/flows/PresetFlowsRow';
+import { SaveFlowButton } from '@/components/flows/SaveFlowButton';
 
 const DashboardPage = () => {
+  const [flowName, setFlowName] = useState("");
+
   return (
     <div className="container mx-auto p-4 md:p-8">
       <h1 className="text-4xl font-bold mb-8">Your Dashboard</h1>
+
+      <PresetFlowsRow />
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-8 mb-8">
+        <div className="card p-6 flex flex-col">
+          <label className="block text-sm font-medium mb-2" htmlFor="flowName">
+            Flow Name
+          </label>
+          <input
+            id="flowName"
+            className="input"
+            placeholder="Evening Unwind"
+            value={flowName}
+            onChange={(e) => setFlowName(e.target.value)}
+          />
+        </div>
+
+        <AIFlowGenerator />
+
+        <div className="card p-6 flex items-center justify-center">
+          <SaveFlowButton flowName={flowName} />
+        </div>
+      </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-8">
         {/* Main column */}
         <div className="lg:col-span-2">
           <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
-            {/* Quick Actions */}
-            <div className="card p-6">
-              <h2 className="text-2xl font-bold mb-4">Quick Actions</h2>
-              <AIFlowGenerator />
-            </div>
-
             {/* Practice Statistics */}
             <div className="card p-6">
               <h2 className="text-2xl font-bold mb-4">Practice Statistics</h2>
@@ -23,6 +46,13 @@ const DashboardPage = () => {
               <p>Total Sessions: 0</p>
               <p>Time Practiced: 0 mins</p>
               <p>Current Streak: 0 days</p>
+            </div>
+
+            {/* Quick Actions / Placeholder */}
+            <div className="card p-6">
+              <h2 className="text-2xl font-bold mb-4">Quick Actions</h2>
+              {/* Additional quick actions can go here */}
+              <p className="text-muted-foreground">Select a preset or generate a flow.</p>
             </div>
           </div>
 

--- a/src/components/flows/PresetFlowsRow.tsx
+++ b/src/components/flows/PresetFlowsRow.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { PRESETS } from "@/lib/yoga-data";
+import { PoseId } from "@/types/yoga";
+
+interface PresetFlowsRowProps {
+  onSelect?: (flow: PoseId[]) => void;
+}
+
+export const PresetFlowsRow = ({ onSelect }: PresetFlowsRowProps) => {
+  return (
+    <div className="flex gap-2 overflow-x-auto pb-2 mb-4">
+      {PRESETS.map((preset) => (
+        <button
+          key={preset.name}
+          onClick={() => onSelect?.(preset.flow)}
+          className="btn btn-outline whitespace-nowrap"
+        >
+          {preset.name}
+        </button>
+      ))}
+    </div>
+  );
+};

--- a/src/components/flows/SaveFlowButton.tsx
+++ b/src/components/flows/SaveFlowButton.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+interface SaveFlowButtonProps {
+  flowName: string;
+}
+
+export const SaveFlowButton = ({ flowName }: SaveFlowButtonProps) => {
+  const handleSave = () => {
+    const flow = {
+      schema: "flow.v1",
+      id: crypto.randomUUID(),
+      name: flowName || "Untitled Flow",
+      timingMode: "pose",
+      tts: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      tags: [],
+      blocks: [],
+    };
+
+    const blob = new Blob([JSON.stringify(flow, null, 2)], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `${flow.name}.json`;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  return (
+    <button onClick={handleSave} className="btn btn-secondary w-full">
+      Save to Device
+    </button>
+  );
+};

--- a/src/lib/yoga-data.ts
+++ b/src/lib/yoga-data.ts
@@ -21,6 +21,8 @@ export const FOCI: readonly Focus[] = ["Full-Body", "Hips", "Hamstrings", "Shoul
 export const PRESETS: { name: string; flow: PoseId[] }[] = [
   { name: "Quick Core 15", flow: [PoseId.Boat, PoseId.Boat, PoseId.Bridge, PoseId.DownDog, PoseId.Child] },
   { name: "Hip Opener 30", flow: [PoseId.Butterfly, PoseId.Pigeon, PoseId.Pigeon, PoseId.TwistLow, PoseId.ForwardFold, PoseId.Child] },
-  { name: "Morning Wake Up", flow: [PoseId.Child, PoseId.ForwardFold, PoseId.DownDog, PoseId.Warrior1Right, PoseId.HighLungeRight, PoseId.Bridge, PoseId.Child] },
-  { name: "Evening Cool Down", flow: [PoseId.Butterfly, PoseId.ForwardFold, PoseId.Pigeon, PoseId.TwistLow, PoseId.Child] },
+  { name: "Morning Wake-Up", flow: [PoseId.Child, PoseId.ForwardFold, PoseId.DownDog, PoseId.Warrior1Right, PoseId.HighLungeRight, PoseId.Bridge, PoseId.Child] },
+  { name: "Evening Unwind", flow: [PoseId.Butterfly, PoseId.ForwardFold, PoseId.Pigeon, PoseId.TwistLow, PoseId.Child] },
+  { name: "Restorative 20", flow: [PoseId.Butterfly, PoseId.ForwardFold, PoseId.Child, PoseId.Child] },
+  { name: "Power 45", flow: [PoseId.DownDog, PoseId.Warrior1Right, PoseId.HighLungeRight, PoseId.Boat, PoseId.Bridge, PoseId.TwistLow, PoseId.Child] },
 ];


### PR DESCRIPTION
## Summary
- add preset flow carousel and save-to-device button on dashboard
- expand default preset flows in yoga-data
- wire dashboard primary actions with flow name input and AI generator

## Testing
- `npm test`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68c1601fefc0832f877097f094c14f60