### PR TITLE
feat: save flows with timestamped filename

### DIFF
--- a/src/components/flows/SaveFlowButton.tsx
+++ b/src/components/flows/SaveFlowButton.tsx
@@ -6,23 +6,44 @@ interface SaveFlowButtonProps {
 
 export const SaveFlowButton = ({ flowName }: SaveFlowButtonProps) => {
   const handleSave = () => {
+    const now = new Date();
+    const slug = (flowName || "untitled")
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "");
+    const timestamp = now
+      .toISOString()
+      .replace(/[-:]/g, "")
+      .slice(0, 15)
+      .replace("T", "_");
+
     const flow = {
       schema: "flow.v1",
       id: crypto.randomUUID(),
       name: flowName || "Untitled Flow",
       timingMode: "pose",
       tts: true,
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
+      createdAt: now.toISOString(),
+      updatedAt: now.toISOString(),
       tags: [],
       blocks: [],
     };
 
-    const blob = new Blob([JSON.stringify(flow, null, 2)], { type: "application/json" });
+    // Persist to localStorage
+    try {
+      const stored = JSON.parse(localStorage.getItem("flows") || "[]");
+      localStorage.setItem("flows", JSON.stringify([...stored, flow]));
+    } catch (e) {
+      // ignore storage errors
+    }
+
+    const blob = new Blob([JSON.stringify(flow, null, 2)], {
+      type: "application/json",
+    });
     const url = URL.createObjectURL(blob);
     const link = document.createElement("a");
     link.href = url;
-    link.download = `${flow.name}.json`;
+    link.download = `flow_${slug}_${timestamp}.json`;
     link.click();
     URL.revokeObjectURL(url);
   };


### PR DESCRIPTION
## Summary
- slugify flow names and add timestamped filenames when saving flows
- persist saved flows to localStorage

## Testing
- `npm test`
- `npm run lint` *(fails: interactive prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68c164903cc4832fa88c153631a08530