### PR TITLE
feat: add public dashboard page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "clsx": "^2.1.1",
         "fuse.js": "^7.1.0",
         "gray-matter": "^4.0.3",
+        "lucide-react": "^0.447.0",
         "next": "13.5.6",
         "react": "^18",
         "react-dom": "^18",
@@ -6285,6 +6286,15 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/lucide-react": {
+      "version": "0.447.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.447.0.tgz",
+      "integrity": "sha512-SZ//hQmvi+kDKrNepArVkYK7/jfeZ5uFNEnYmd45RKZcbGD78KLnrcNXmgeg6m+xNHFvTG+CblszXCy4n6DN4w==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.18",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "clsx": "^2.1.1",
     "fuse.js": "^7.1.0",
     "gray-matter": "^4.0.3",
+    "lucide-react": "^0.447.0",
     "next": "13.5.6",
     "react": "^18",
     "react-dom": "^18",

--- a/src/app/(public)/dashboard/page.tsx
+++ b/src/app/(public)/dashboard/page.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { PageLayout } from '@/components/layout/PageLayout';
+import { FeatureCard } from '@/components/dashboard/FeatureCard';
+import { StatCard } from '@/components/dashboard/StatCard';
+import { SectionHeader } from '@/components/ui/SectionHeader';
+import { fetchDashboardData } from '@/lib/api/dashboard';
+
+const DashboardPage = async () => {
+  const data = await fetchDashboardData();
+
+  const features = [
+    { title: 'Pose Library', description: 'Browse detailed instructions for each pose.' },
+    { title: 'Create Flow', description: 'Generate a custom yoga flow using AI.' },
+    { title: 'PDF Manual', description: 'Download the comprehensive practice manual.' },
+  ];
+
+  return (
+    <PageLayout title="Dashboard" description="Welcome to Yoga Flow University.">
+      <section className="mb-8">
+        <SectionHeader title="Quick Start" />
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {features.map((feature) => (
+            <FeatureCard key={feature.title} {...feature} />
+          ))}
+        </div>
+      </section>
+      <section>
+        <SectionHeader title="Your Practice" />
+        <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {data.stats.map((stat) => (
+            <StatCard key={stat.title} {...stat} />
+          ))}
+        </div>
+      </section>
+    </PageLayout>
+  );
+};
+
+export default DashboardPage;

--- a/src/components/dashboard/FeatureCard.tsx
+++ b/src/components/dashboard/FeatureCard.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Card, CardHeader, CardTitle, CardDescription } from '@/components/ui/Card';
+
+interface FeatureCardProps {
+  title: string;
+  description: string;
+}
+
+export const FeatureCard: React.FC<FeatureCardProps> = ({ title, description }) => {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{title}</CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+    </Card>
+  );
+};

--- a/src/components/dashboard/StatCard.tsx
+++ b/src/components/dashboard/StatCard.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Card, CardContent } from '@/components/ui/Card';
+import { Metric } from '@/components/ui/Metric';
+
+interface StatCardProps {
+  title: string;
+  value: string | number;
+}
+
+export const StatCard: React.FC<StatCardProps> = ({ title, value }) => {
+  return (
+    <Card>
+      <CardContent className="p-4">
+        <Metric label={title} value={value} />
+      </CardContent>
+    </Card>
+  );
+};

--- a/src/components/ui/Metric.tsx
+++ b/src/components/ui/Metric.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+interface MetricProps extends React.HTMLAttributes<HTMLDivElement> {
+  label: string;
+  value: string | number;
+}
+
+export const Metric: React.FC<MetricProps> = ({ label, value, className, ...props }) => (
+  <div className={cn(className)} {...props}>
+    <div className="text-2xl font-bold">{value}</div>
+    <p className="text-sm text-muted-foreground">{label}</p>
+  </div>
+);

--- a/src/components/ui/SectionHeader.tsx
+++ b/src/components/ui/SectionHeader.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+interface SectionHeaderProps extends React.HTMLAttributes<HTMLDivElement> {
+  title: string;
+  description?: string;
+}
+
+export const SectionHeader: React.FC<SectionHeaderProps> = ({ title, description, className, ...props }) => {
+  return (
+    <div className={cn('mb-4', className)} {...props}>
+      <h2 className="text-2xl font-bold tracking-tight">{title}</h2>
+      {description && <p className="text-muted-foreground">{description}</p>}
+    </div>
+  );
+};

--- a/src/components/ui/index.tsx
+++ b/src/components/ui/index.tsx
@@ -8,3 +8,5 @@ export * from './Select';
 export * from './Toggle';
 export * from './Tabs';
 export * from './EmptyState';
+export * from './Metric';
+export * from './SectionHeader';

--- a/src/lib/api/dashboard.ts
+++ b/src/lib/api/dashboard.ts
@@ -1,0 +1,12 @@
+import { DashboardData } from '@/types/dashboard';
+
+export async function fetchDashboardData(): Promise<DashboardData> {
+  // TODO: replace with real API call
+  return {
+    stats: [
+      { title: 'Total Sessions', value: 0 },
+      { title: 'Minutes Practiced', value: 0 },
+      { title: 'Current Streak', value: '0 days' },
+    ],
+  };
+}

--- a/src/types/dashboard.ts
+++ b/src/types/dashboard.ts
@@ -1,0 +1,8 @@
+export interface DashboardStat {
+  title: string;
+  value: string | number;
+}
+
+export interface DashboardData {
+  stats: DashboardStat[];
+}


### PR DESCRIPTION
## Summary
- scaffold dashboard page with SectionHeader and Metric primitives
- add typed dashboard data contracts and API stub
- simplify FeatureCard and StatCard to use shared primitives

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c16a7d6928832f8b3a148430ad11e2