### PR TITLE
fix: Expose OPENAI_API_KEY to Next.js server runtime

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  env: {
+    OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+  },
   // Temporarily disable static export for API routes development
   // output: 'export',
   eslint: {


### PR DESCRIPTION
This change modifies the next.config.js file to explicitly expose the OPENAI_API_KEY environment variable to the Next.js server-side runtime. This is necessary to ensure that the OpenAI API key is available to the API routes when deployed on Netlify, as the default environment variable handling may not be sufficient.