### PR TITLE
fix: Securely provide OpenAI API key to server runtime

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,8 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  serverRuntimeConfig: {
+    OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+  },
   // Temporarily disable static export for API routes development
   // output: 'export',
   eslint: {

--- a/src/lib/openai.ts
+++ b/src/lib/openai.ts
@@ -1,14 +1,18 @@
 import OpenAI from "openai";
+import getConfig from 'next/config';
+
+const { serverRuntimeConfig } = getConfig() || {};
+const apiKey = serverRuntimeConfig?.OPENAI_API_KEY || process.env.OPENAI_API_KEY;
 
 // Validate environment variables
-if (!process.env.OPENAI_API_KEY && process.env.USE_MOCK !== "true") {
+if (!apiKey && process.env.USE_MOCK !== "true") {
   console.warn("OPENAI_API_KEY missing - API calls will use fallback responses");
 }
 
 // Main OpenAI client - only created when API key is available
-export const openai = process.env.OPENAI_API_KEY 
+export const openai = apiKey
   ? new OpenAI({
-      apiKey: process.env.OPENAI_API_KEY,
+      apiKey,
     })
   : null;
 


### PR DESCRIPTION
This change fixes the issue of the OpenAI API key not being available to the server-side code on Netlify. It uses `serverRuntimeConfig` in `next.config.js` to securely expose the `OPENAI_API_KEY` to the server-side runtime without leaking it to the client-side bundle.

The previous attempt to fix this using the `env` property in `next.config.js` was incorrect as it exposed the key to the client, causing the build to fail due to Netlify's secret scanning.

This new approach is secure and follows best practices for handling server-side secrets in a Next.js application.