### PR TITLE
feat: Add robots.txt to fix AdSense verification

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,14 @@
+User-Agent: *
+Allow: /
+Disallow: /admin/
+Disallow: /api/
+Disallow: /_next/
+Disallow: /dashboard
+Disallow: /journal/
+Disallow: /reading/
+
+User-Agent: AdsBot-Google
+Allow: /
+
+Host: https://fltwht.com
+Sitemap: https://fltwht.com/sitemap.xml


### PR DESCRIPTION
Adds a `robots.txt` file to the `public/` directory to override platform-level configurations and ensure proper crawler access for Google AdSense verification.

The new `robots.txt` file:
- Corrects the `Host` and `Sitemap` directives to point to `fltwht.com`.
- Explicitly allows `AdsBot-Google` to crawl the site.
- Simplifies rules for other crawlers.

This change is intended to resolve the AdSense verification issue caused by an incorrect `robots.txt` file being served by the hosting platform.