### PR TITLE
Update robots base URL domain

### DIFF
--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,7 +1,7 @@
 import { MetadataRoute } from 'next';
 
 export default function robots(): MetadataRoute.Robots {
-  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://yoga-university.com';
+  const baseUrl = process.env.NEXT_PUBLIC_BASE_URL || 'https://fltwht.com';
   
   return {
     rules: [


### PR DESCRIPTION
## Summary
- update the robots metadata route to default to the new fltwht.com domain

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68dbbf5c8564832fb75b97245bd2f46d