### PR TITLE
fix: Force Node.js runtime for AI API routes on Netlify

### DIFF
--- a/src/app/api/ai-guide/route.ts
+++ b/src/app/api/ai-guide/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { oa, isOpenAIAvailable } from "@/lib/openai";
 
+export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: Request) {

--- a/src/app/api/ai-recap/route.ts
+++ b/src/app/api/ai-recap/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { oa, isOpenAIAvailable } from "@/lib/openai";
 
+export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: Request) {

--- a/src/app/api/ai-script/route.ts
+++ b/src/app/api/ai-script/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { oa, isOpenAIAvailable } from "@/lib/openai";
 
+export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: Request) {

--- a/src/app/api/ai-select/route.ts
+++ b/src/app/api/ai-select/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { oa, isOpenAIAvailable } from "@/lib/openai";
 import ErrorReporter from "@/lib/errorReporting";
 
+export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export async function POST(req: Request) {

--- a/src/app/api/ai/adapt-flow/route.ts
+++ b/src/app/api/ai/adapt-flow/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { generateCompletion, filterContent } from '@/lib/openai';
 import { PoseId } from '@/types/yoga';
 
+export const runtime = 'nodejs';
+
 export interface FlowAdaptationRequest {
   currentFlow: {
     poses: PoseId[];

--- a/src/app/api/ai/affirmations/route.ts
+++ b/src/app/api/ai/affirmations/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { generateCompletion, filterContent } from '@/lib/openai';
 
+export const runtime = 'nodejs';
+
 export interface AffirmationRequest {
   context: 'meditation' | 'flow' | 'general';
   userProfile?: {

--- a/src/app/api/ai/generateFlow/route.ts
+++ b/src/app/api/ai/generateFlow/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { createClient } from '@/utils/supabase/server';
 import { generateFlow } from '@/lib/ai';
+
+export const runtime = 'nodejs';
 import { AIGenerationParams } from '@/types/ai';
 
 export async function POST(request: Request) {

--- a/src/app/api/ai/progress-insights/route.ts
+++ b/src/app/api/ai/progress-insights/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse } from 'next/server';
 import { ProgressAnalyticsService, ProgressInsights } from '@/lib/services/progressAnalytics';
 import { PracticeSession } from '@/types/dashboard';
 
+export const runtime = 'nodejs';
+
 export async function GET(request: NextRequest) {
   return NextResponse.json({
     message: 'AI Progress Insights API',

--- a/src/app/api/ai/validateSequence/route.ts
+++ b/src/app/api/ai/validateSequence/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { openai, isOpenAIAvailable } from '@/lib/openai';
 import { PoseId } from '@/types/yoga';
+
+export const runtime = 'nodejs';
 import { POSES } from '@/lib/yoga-data';
 
 interface ValidationRequest {


### PR DESCRIPTION
This commit resolves a critical issue where AI-related API routes were failing in the Netlify production environment. The root cause was that the Next.js build process was defaulting these routes to the Edge runtime, which is incompatible with the Node.js-specific code used for OpenAI API calls.

To fix this, `export const runtime = 'nodejs';` has been added to all relevant AI API routes. This ensures that they are correctly bundled as Netlify Serverless Functions, allowing them to execute successfully.

Additionally, the `OPENAI_TROUBLESHOOTING.md` file has been updated to prioritize this build configuration issue as the primary solution for production failures. A `.env.local` file has also been added to improve the local development setup.